### PR TITLE
Add instances for serialise (CBOR)

### DIFF
--- a/strict/src/Data/Strict.hs
+++ b/strict/src/Data/Strict.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Safe #-}
-
 -- | Strict versions of some standard Haskell types.
 module Data.Strict (
     module Data.Strict.Classes

--- a/strict/src/Data/Strict/Classes.hs
+++ b/strict/src/Data/Strict/Classes.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FunctionalDependencies #-}
 #if MIN_VERSION_base(4,8,0)
-{-# LANGUAGE Safe #-}
 #else
 {-# LANGUAGE Trustworthy #-}
 #endif

--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE DeriveGeneric      #-}
 
 #if MIN_VERSION_base(4,9,0)
@@ -47,6 +46,7 @@ import           Data.Traversable (Traversable (..))
 -- Lazy variants
 import qualified Prelude             as L
 
+import           Codec.Serialise     (Serialise (..))
 import           Control.DeepSeq     (NFData (..))
 import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
@@ -178,6 +178,11 @@ instance NFData2 Either where
 instance (Binary a, Binary b) => Binary (Either a b) where
   put = put . toLazy
   get = toStrict <$> get
+
+-- serialise
+instance (Serialise a, Serialise b) => Serialise (Either a b) where
+  encode = encode . toLazy
+  decode = toStrict <$> decode
 
 -- bifunctors
 instance Bifunctor Either where

--- a/strict/src/Data/Strict/Maybe.hs
+++ b/strict/src/Data/Strict/Maybe.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE DeriveGeneric      #-}
 
 #if MIN_VERSION_base(4,9,0)
@@ -58,6 +57,7 @@ import           Data.Traversable (Traversable (..))
 -- Lazy variants
 import qualified Prelude             as L
 
+import           Codec.Serialise     (Serialise (..))
 import           Control.DeepSeq     (NFData (..))
 import           Data.Binary         (Binary (..))
 import           Data.Hashable       (Hashable(..))
@@ -194,6 +194,11 @@ instance NFData1 Maybe where
 instance Binary a => Binary (Maybe a) where
   put = put . toLazy
   get = toStrict <$> get
+
+-- serialise
+instance Serialise a => Serialise (Maybe a) where
+  encode = encode . toLazy
+  decode = toStrict <$> decode
 
 -- hashable
 instance Hashable a => Hashable (Maybe a) where

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE DeriveGeneric      #-}
 #ifndef __HADDOCK__
 #ifdef __GLASGOW_HASKELL__
@@ -58,6 +57,7 @@ import           Data.Traversable (Traversable (..))
 -- Lazy variants
 import qualified Prelude             as L
 
+import           Codec.Serialise     (Serialise (..))
 import           Control.DeepSeq     (NFData (..))
 import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
@@ -186,6 +186,11 @@ instance NFData2 Pair where
 instance (Binary a, Binary b) => Binary (Pair a b) where
   put = put . toLazy
   get = toStrict <$> get
+
+-- serialise
+instance (Serialise a, Serialise b) => Serialise (Pair a b) where
+  encode = encode . toLazy
+  decode = toStrict <$> decode
 
 -- bifunctors
 instance Bifunctor Pair where

--- a/strict/strict.cabal
+++ b/strict/strict.cabal
@@ -82,6 +82,7 @@ library
     , bytestring   >= 0.9.2.1 && < 0.11
     , deepseq      >= 1.3.0.0 && < 1.5
     , hashable     >= 1.2.7.0 && < 1.4
+    , serialise    >= 0.2.0.0 && < 0.3
     , text         >= 1.2.3.0 && < 1.3
     , these        >= 1.1.1.1 && < 1.2
     , transformers >= 0.3.0.0 && < 0.6


### PR DESCRIPTION
However, as serialise is not Safe we have to get rid of that on our modules too. :( @phadej Do you have an alternate suggestion?

Also `these` does not itself define instances for `Serialise` so we omit them from this PR for now, but they could be added once the former adds them.
