### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/strict/strict.cabal
+++ b/strict/strict.cabal
@@ -79,7 +79,7 @@ library
   build-depends:
       base         >= 4.5.0.0 && < 5
     , binary       >= 0.5.1.0 && < 0.9
-    , bytestring   >= 0.9.2.1 && < 0.11
+    , bytestring   >= 0.9.2.1 && < 0.12
     , deepseq      >= 1.3.0.0 && < 1.5
     , hashable     >= 1.2.7.0 && < 1.4
     , text         >= 1.2.3.0 && < 1.3


### PR DESCRIPTION
Tested using 
```
packages: strict/
-- packages: strict-lens/
-- packages: strict-base-types/
-- packages: strict-optics/

constraints:
  bytestring >=0.11

allow-newer:
  hashable:bytestring,
  uuid-types:bytestring,
  lens:bytestring

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

-- https://github.com/bgamari/attoparsec/pull/5
source-repository-package
  type: git
  location: https://github.com/phadej/attoparsec
  tag: 7efaa371058c1092b728c973c778704a167bc04c
```