### PR TITLE
Add a flag for avoiding the binary dependency

### DIFF
--- a/strict/CHANGELOG.md
+++ b/strict/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.0.2
+
+- Add flag for avoiding the `binary` dependency. This is intended for testing
+  purposes e.g. to break dependency cycles in GHC bootstrapping libraries.
+
 # 0.4.0.1
 
 - Allow `bytestring-0.11`

--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -50,7 +50,9 @@ import qualified Prelude             as L
 import           Control.DeepSeq     (NFData (..))
 import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
+#ifdef MIN_VERSION_binary
 import           Data.Binary         (Binary (..))
+#endif
 import           Data.Bitraversable  (Bitraversable (..))
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..), Hashable2 (..))
@@ -174,10 +176,12 @@ instance NFData2 Either where
   liftRnf2 rnfA rnfB = liftRnf2 rnfA rnfB . toLazy
 #endif
 
+#ifdef MIN_VERSION_binary
 -- binary
 instance (Binary a, Binary b) => Binary (Either a b) where
   put = put . toLazy
   get = toStrict <$> get
+#endif
 
 -- bifunctors
 instance Bifunctor Either where

--- a/strict/src/Data/Strict/Maybe.hs
+++ b/strict/src/Data/Strict/Maybe.hs
@@ -59,7 +59,9 @@ import           Data.Traversable (Traversable (..))
 import qualified Prelude             as L
 
 import           Control.DeepSeq     (NFData (..))
+#ifdef MIN_VERSION_binary
 import           Data.Binary         (Binary (..))
+#endif
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..))
 import           GHC.Generics        (Generic)
@@ -190,10 +192,12 @@ instance NFData1 Maybe where
   liftRnf rnfA = liftRnf rnfA . toLazy
 #endif
 
+#ifdef MIN_VERSION_binary
 -- binary
 instance Binary a => Binary (Maybe a) where
   put = put . toLazy
   get = toStrict <$> get
+#endif
 
 -- hashable
 instance Hashable a => Hashable (Maybe a) where

--- a/strict/src/Data/Strict/These.hs
+++ b/strict/src/Data/Strict/These.hs
@@ -43,7 +43,9 @@ import Control.Applicative  (Applicative (..), (<$>))
 import Control.DeepSeq      (NFData (..))
 import Data.Bifoldable      (Bifoldable (..))
 import Data.Bifunctor       (Bifunctor (..))
+#ifdef MIN_VERSION_binary
 import Data.Binary          (Binary (..))
+#endif
 import Data.Bitraversable   (Bitraversable (..))
 import Data.Data            (Data, Typeable)
 import Data.Either          (partitionEithers)
@@ -401,9 +403,11 @@ instance NFData2 These where
 -- binary
 -------------------------------------------------------------------------------
 
+#ifdef MIN_VERSION_binary
 instance (Binary a, Binary b) => Binary (These a b) where
     put = put . toLazy
     get = toStrict <$> get
+#endif
 
 -------------------------------------------------------------------------------
 -- hashable

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -61,7 +61,9 @@ import qualified Prelude             as L
 import           Control.DeepSeq     (NFData (..))
 import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
+#ifdef MIN_VERSION_binary
 import           Data.Binary         (Binary (..))
+#endif
 import           Data.Bitraversable  (Bitraversable (..))
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..), Hashable2 (..))
@@ -182,10 +184,12 @@ instance NFData2 Pair where
   liftRnf2 rnfA rnfB = liftRnf2 rnfA rnfB . toLazy
 #endif
 
+#ifdef MIN_VERSION_binary
 -- binary
 instance (Binary a, Binary b) => Binary (Pair a b) where
   put = put . toLazy
   get = toStrict <$> get
+#endif
 
 -- bifunctors
 instance Bifunctor Pair where

--- a/strict/strict.cabal
+++ b/strict/strict.cabal
@@ -1,5 +1,5 @@
 Name:           strict
-Version:        0.4.0.1
+Version:        0.4.0.2
 Synopsis:       Strict data types and String IO.
 Category:       Data, System
 Description:
@@ -72,6 +72,11 @@ flag assoc
   manual:      True
   default:     True
 
+flag binary
+  description: Build with binary dependency
+  manual:      True
+  default:     True
+
 library
   default-language: Haskell2010
   hs-source-dirs:   src
@@ -79,7 +84,6 @@ library
 
   build-depends:
       base         >= 4.5.0.0 && < 5
-    , binary       >= 0.5.1.0 && < 0.9
     , bytestring   >= 0.9.2.1 && < 0.12
     , deepseq      >= 1.3.0.0 && < 1.5
     , hashable     >= 1.2.7.0 && < 1.4
@@ -103,6 +107,9 @@ library
 
   if flag(assoc)
     build-depends: assoc >= 1.0.1 && < 1.1
+
+  if flag(binary)
+    build-depends: binary >= 0.5.1.0 && < 0.9
 
   exposed-modules:
     Data.Strict


### PR DESCRIPTION
I'm experimenting with de-duplicating StrictPair/StrictMaybe out of the containers library and need this flag to the dependency cycle strict -> binary -> containers -> strict.