### PR TITLE
correct constructor used by docs

### DIFF
--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -26,7 +26,7 @@
 -- The strict variant of the standard Haskell pairs and the corresponding
 -- variants of the functions from "Data.Tuple".
 --
--- Note that unlike regular Haskell pairs, @(x :*: _|_) = (_|_ :*: y) = _|_@
+-- Note that unlike regular Haskell pairs, @(x :!: _|_) = (_|_ :!: y) = _|_@
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
the docs mention `:*:` but the constructor is `:!:`, seems just wrong to me